### PR TITLE
feat: improve linter

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -44,12 +44,13 @@ function createCache(cwd: string, filePath = cwd) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const prettier: CacheInstance['prettier'] = require(prettierPath)
   const configPath = prettier.resolveConfigFile.sync(filePath)
+
   const ignorePath = path.join(cwd, '.prettierignore')
   const options =
     prettier.resolveConfig.sync(filePath, {
       useCache: false,
       editorconfig: true,
-    }) || {}
+    }) ?? {}
 
   const cacheInstance: CacheInstance = {
     prettier,

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -130,7 +130,7 @@ export const invoke = (
   args: string[],
   text: string,
   mtime: number,
-  callback: (output: string) => void,
+  callback: (err: unknown, response: string) => void,
 ) => {
   process.chdir(cwd)
 
@@ -145,11 +145,10 @@ export const invoke = (
 
   // Skip if there is no prettier config.
   if (!cache.hasConfig) {
-    callback(text)
+    callback(null, text)
     return
   }
 
-  const parsedOptions = parseArguments(args)
   const filePath = parsedOptions.filepath
 
   if (!filePath) {
@@ -166,7 +165,7 @@ export const invoke = (
 
   // Skip if file is ignored.
   if (fileInfo.ignored) {
-    callback(text)
+    callback(null, text)
     return
   }
 
@@ -184,7 +183,10 @@ export const invoke = (
     options.filepath = parsedOptions.filepath
   }
 
-  callback(cache.prettier.format(parsedOptions.text || text, options))
+  callback(
+    null,
+    cache.prettier.format(parsedOptions.text ?? text, options),
+  )
 }
 
 export const cache = prettierCache

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -6,6 +6,29 @@ import LRU from 'nanolru'
 import { Options } from 'prettier'
 import resolve from 'resolve'
 
+export interface CacheInstance {
+  hasConfig: boolean
+  ignorePath: string
+  options: Options
+  prettier: typeof import('prettier')
+  lastRun?: number
+}
+
+export type ParsedOptions = Options & {
+  // Added by prettier_d_slim.
+  stdin?: boolean
+  stdinFilepath?: string
+  // Alternate way of passing text
+  text?: string
+  // Colon separated string.
+  pluginSearchDir?: string
+  // Colon separated string.
+  plugin?: string
+
+  // Used in prettier cli.
+  configPrecedence?: string
+}
+
 const prettierCache = new LRU<CacheInstance>(10)
 
 function createCache(cwd: string) {
@@ -177,12 +200,4 @@ export const getStatus = () => {
     return 'One instance cached.'
   }
   return `${keys.length} instances cached.`
-}
-
-export interface CacheInstance {
-  hasConfig: boolean
-  ignorePath: string
-  options: Options
-  prettier: typeof import('prettier')
-  lastRun?: number
 }


### PR DESCRIPTION
This PR aims to fix the following issues:

- Improve readability somewhat
- Initially resolve config from `filePath` rather than the given `cwd`. This is how `prettier` is intended to do the lookup. (see https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options and https://prettier.io/docs/en/api.html#prettierresolveconfigfilefilepath)
- Use `invoke` and its `callback` correctly - `callback(err, res)`. Before `prettier_d_slim` send the result as an `err`. Unsure how it was possible for it to even work before. (see https://github.com/mantoni/core_d.js#api)
- Handle `--no-` options correctly by omitting them or negating them.

This is tested and multiple repos and filetypes. It works on both monorepos and regular repos, by finding the closest config and resolving the local `prettier` correctly.

Closes #8
Closes #9